### PR TITLE
Add configurable initial population sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,6 @@ Parameters exposed in the sidebar correspond to fields in `simulation.Config`:
 - `age_partner_to_emeritus` – age at which partners become emeritus.
 - `age_econ_rights_end` – age when economic rights expire.
 - `eligible_parent_status` – partner statuses considered when evaluating invitation eligibility.
+- `initial_active_partners`, `initial_emeritus_partners`, and `initial_trainees` – numbers of each group present at the start of the simulation.
 
-Tweak these values in the sidebar and rerun to explore different scenarios.
+Tweak these values in the sidebar (or by creating a `Config` manually) and rerun to explore different scenarios.

--- a/simulation.py
+++ b/simulation.py
@@ -28,6 +28,10 @@ class Config:
     age_partner_to_emeritus: int = 55
     age_econ_rights_end: int = 65
     eligible_parent_status: List[str] = field(default_factory=lambda: ['partner_active','partner_emeritus'])
+    # Initial population sizes
+    initial_active_partners: int = 30
+    initial_emeritus_partners: int = 30
+    initial_trainees: int = 10
 
 @dataclass
 class Person:
@@ -78,9 +82,9 @@ class Simulation:
                     pass
                 self.people[self.next_id] = p
                 self.next_id += 1
-        create_many(30,'partner_active',35,55)
-        create_many(30,'partner_emeritus',56,85)
-        create_many(10,'trainee',27,32)
+        create_many(self.cfg.initial_active_partners,'partner_active',35,55)
+        create_many(self.cfg.initial_emeritus_partners,'partner_emeritus',56,85)
+        create_many(self.cfg.initial_trainees,'trainee',27,32)
 
     def _add_person_from_row(self,row):
         # Basic type validation for key fields


### PR DESCRIPTION
## Summary
- allow the initial number of active partners, emeriti, and trainees to be set via `Config`
- use these counts when bootstrapping a simulation
- document the new settings in README

## Testing
- `python -m py_compile simulation.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6889eb90404c8322a7d20a11dce60b73